### PR TITLE
Cleanup: Move `check_version` to main cli entrypoint

### DIFF
--- a/cirro/cli/cli.py
+++ b/cirro/cli/cli.py
@@ -1,4 +1,7 @@
+import importlib
+
 import click
+import requests
 from cirro_api_client.v1.errors import CirroException
 
 from cirro.cli import run_ingest, run_download, run_configure, run_list_datasets, run_create_pipeline_config
@@ -125,8 +128,30 @@ def create_pipeline_config(**kwargs):
     run_create_pipeline_config(kwargs, interactive=kwargs.get('interactive'))
 
 
+def _check_version():
+    """
+    Prompts the user to update their package version if needed
+    """
+    yellow_color = '\033[93m'
+    reset_color = '\033[0m'
+
+    try:
+        current_version = importlib.metadata.version('cirro')
+        response = requests.get("https://pypi.org/pypi/cirro/json")
+        response.raise_for_status()
+        latest_version = response.json()["info"]["version"]
+
+        if current_version != latest_version:
+            print(f"{yellow_color}Warning:{reset_color} Cirro version {current_version} "
+                  f"is out of date. Update to {latest_version} with 'pip install cirro --upgrade'.")
+
+    except Exception:
+        return
+
+
 def main():
     try:
+        _check_version()
         run()
     except InputError as e:
         handle_error(e)

--- a/cirro/cli/controller.py
+++ b/cirro/cli/controller.py
@@ -1,11 +1,9 @@
-import importlib.metadata
 import json
 import logging
 import os
 import sys
 from pathlib import Path
 
-import requests
 from cirro_api_client.v1.models import UploadDatasetRequest, Status, Executor
 
 from cirro.cirro_client import CirroApi
@@ -39,7 +37,6 @@ logger.addHandler(console_handler)
 def run_list_datasets(input_params: ListArguments, interactive=False):
     """List the datasets available in a particular project."""
     _check_configure()
-    _check_version()
     cirro = CirroApi()
     logger.info(f"Collecting data from {cirro.configuration.base_url}")
     projects = cirro.projects.list()
@@ -66,7 +63,6 @@ def run_list_datasets(input_params: ListArguments, interactive=False):
 
 def run_ingest(input_params: UploadArguments, interactive=False):
     _check_configure()
-    _check_version()
     cirro = CirroApi()
     logger.info(f"Collecting data from {cirro.configuration.base_url}")
     processes = cirro.processes.list(process_type=Executor.INGEST)
@@ -125,7 +121,6 @@ def run_ingest(input_params: UploadArguments, interactive=False):
 
 def run_download(input_params: DownloadArguments, interactive=False):
     _check_configure()
-    _check_version()
     cirro = CirroApi()
     logger.info(f"Collecting data from {cirro.configuration.base_url}")
 
@@ -182,7 +177,6 @@ def run_download(input_params: DownloadArguments, interactive=False):
 
 def run_upload_reference(input_params: UploadReferenceArguments, interactive=False):
     _check_configure()
-    _check_version()
     cirro = CirroApi()
     logger.info(f"Collecting data from {cirro.configuration.base_url}")
 
@@ -207,7 +201,6 @@ def run_upload_reference(input_params: UploadReferenceArguments, interactive=Fal
 
 
 def run_configure():
-    _check_version()
     auth_method, base_url, auth_method_config, enable_additional_checksum = gather_auth_config()
     save_user_config(UserConfig(auth_method=auth_method,
                                 auth_method_config=auth_method_config,
@@ -221,7 +214,6 @@ def run_create_pipeline_config(input_params: CreatePipelineConfigArguments, inte
     Creates the pipeline configuration files for the CLI.
     This is a placeholder function that can be expanded in the future.
     """
-    _check_version()
     logger.info("Creating pipeline configuration files...")
 
     if interactive:
@@ -275,27 +267,6 @@ def _check_configure():
     # Legacy check for old config
     if config.base_url == 'cirro.bio':
         run_configure()
-
-
-def _check_version():
-    """
-    Prompts the user to update their package version if needed
-    """
-    yellow_color = '\033[93m'
-    reset_color = '\033[0m'
-
-    try:
-        current_version = importlib.metadata.version('cirro')
-        response = requests.get("https://pypi.org/pypi/cirro/json")
-        response.raise_for_status()
-        latest_version = response.json()["info"]["version"]
-
-        if current_version != latest_version:
-            print(f"{yellow_color}Warning:{reset_color} Cirro version {current_version} "
-                  f"is out of date. Update to {latest_version} with 'pip install cirro --upgrade'.")
-
-    except Exception:
-        return
 
 
 def handle_error(e: Exception):


### PR DESCRIPTION
Don't call `check_version` on each CLI command