### PR TITLE
Remove additional checksum option

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,16 +188,12 @@ The `transfer_max_retries` configuration property specifies the maximum number o
 When uploading files to Cirro, network issues or temporary outages can occasionally cause a transfer to fail.
 It will pause for an increasing amount of time for each retry attempt.
 
-The `enable_additional_checksums` property manages the utilization of SHA-256 hashing for enhanced data integrity. 
-This feature computes the SHA-256 hash of a file during the upload process, and subsequently cross-validates it with the server upon completion.
-When retrieving files, it ensures that the hash received matches the server's stored hash.
 The default hashing algorithm for files is CRC64. In many cases, CRC64 is sufficient to ensure data integrity upon upload.
 
 ```ini
 [General]
 base_url = cirro.bio
 transfer_max_retries = 15
-enable_additional_checksums = true
 ```
 
 ### Clearing saved login

--- a/cirro/cli/controller.py
+++ b/cirro/cli/controller.py
@@ -201,12 +201,11 @@ def run_upload_reference(input_params: UploadReferenceArguments, interactive=Fal
 
 
 def run_configure():
-    auth_method, base_url, auth_method_config, enable_additional_checksum = gather_auth_config()
+    auth_method, base_url, auth_method_config = gather_auth_config()
     save_user_config(UserConfig(auth_method=auth_method,
                                 auth_method_config=auth_method_config,
                                 base_url=base_url,
-                                transfer_max_retries=None,
-                                enable_additional_checksum=enable_additional_checksum))
+                                transfer_max_retries=None))
 
 
 def run_create_pipeline_config(input_params: CreatePipelineConfigArguments, interactive=False):

--- a/cirro/cli/interactive/auth_args.py
+++ b/cirro/cli/interactive/auth_args.py
@@ -7,7 +7,7 @@ from cirro.config import extract_base_url
 logger = logging.getLogger()
 
 
-def gather_auth_config() -> Tuple[str, str, Dict, bool]:
+def gather_auth_config() -> Tuple[str, str, Dict]:
     base_url = ask(
         'text',
         'Enter the URL of the Cirro instance you\'d like to connect to:'
@@ -19,10 +19,4 @@ def gather_auth_config() -> Tuple[str, str, Dict, bool]:
         'enable_cache': ask_yes_no('Would you like to save your login? (do not use this on shared devices)')
     }
 
-    enable_additional_checksum = ask(
-        'select',
-        'Upload / download file validation type (note: SHA-256 requires additional local compute)',
-        choices=['CRC64 (default)', 'SHA-256']
-    ) == 'SHA-256'
-
-    return 'ClientAuth', base_url, auth_method_config, enable_additional_checksum
+    return 'ClientAuth', base_url, auth_method_config

--- a/cirro/config.py
+++ b/cirro/config.py
@@ -20,7 +20,6 @@ class UserConfig(NamedTuple):
     auth_method_config: Dict  # This needs to match the init params of the auth method
     base_url: Optional[str]
     transfer_max_retries: Optional[int]
-    enable_additional_checksum: Optional[bool]
 
 
 def extract_base_url(base_url: str):
@@ -59,7 +58,6 @@ def load_user_config() -> Optional[UserConfig]:
         auth_method = main_config.get('auth_method')
         base_url = main_config.get('base_url')
         transfer_max_retries = main_config.getint('transfer_max_retries', Constants.default_max_retries)
-        enable_additional_checksum = main_config.getboolean('enable_additional_checksum', False)
 
         if auth_method and ini_config.has_section(auth_method):
             auth_method_config = dict(ini_config[auth_method])
@@ -70,8 +68,7 @@ def load_user_config() -> Optional[UserConfig]:
             auth_method=auth_method,
             auth_method_config=auth_method_config,
             base_url=base_url,
-            transfer_max_retries=transfer_max_retries,
-            enable_additional_checksum=enable_additional_checksum
+            transfer_max_retries=transfer_max_retries
         )
     except Exception:
         raise RuntimeError('Configuration load error, please re-run configuration')
@@ -90,8 +87,6 @@ class AppConfig:
         self.base_url = re.compile(r'https?://').sub('', self.base_url).strip()
         self.transfer_max_retries = self.user_config.transfer_max_retries\
             if self.user_config else Constants.default_max_retries
-        self.enable_additional_checksum = self.user_config.enable_additional_checksum\
-            if self.user_config else False
         self._init_config()
 
     @property
@@ -100,7 +95,7 @@ class AppConfig:
 
     @property
     def checksum_method(self):
-        return 'SHA-256' if self.enable_additional_checksum else 'CRC64NVME'
+        return 'CRC64NVME'
 
     def _init_config(self):
         self.rest_endpoint = f'https://{self.base_url}/api'


### PR DESCRIPTION
Remove option to specify SHA-256 checksum, since it is unnecessary and doesn't work with our checksum validation
