### PR TITLE
Specify user agent when using the Cirro CLI

### DIFF
--- a/cirro/cirro_client.py
+++ b/cirro/cirro_client.py
@@ -12,7 +12,7 @@ class CirroApi:
     """
     Client for interacting directly with the Cirro API
     """
-    def __init__(self, auth_info: AuthInfo = None, base_url: str = None):
+    def __init__(self, auth_info: AuthInfo = None, base_url: str = None, user_agent = 'Cirro SDK'):
         """
         Instantiates the Cirro API object
 
@@ -40,7 +40,7 @@ class CirroApi:
         self._api_client = CirroApiClient(
             base_url=self._configuration.rest_endpoint,
             auth_method=auth_info.get_auth_method(),
-            client_name='Cirro SDK',
+            client_name=user_agent,
             package_name='cirro'
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cirro"
-version = "1.8.0"
+version = "1.9.0"
 description = "CLI tool and SDK for interacting with the Cirro platform"
 authors = ["Cirro Bio <support@cirro.bio>"]
 license = "MIT"


### PR DESCRIPTION
- Send Cirro CLI as the user agent when using the CLI entry point, as opposed to the default Cirro SDK user agent
- Cleanup CLI code a bit
- Bump version to 1.9.0